### PR TITLE
Better observation reports

### DIFF
--- a/CactEye 2 BETA 5/GameData/CactEye/Resources/ScienceDefs.cfg
+++ b/CactEye 2 BETA 5/GameData/CactEye/Resources/ScienceDefs.cfg
@@ -11,6 +11,36 @@ EXPERIMENT_DEFINITION
 	RESULTS
 	{
 		default = You make an observation of the body.
+		
+		KerbinInSpaceHigh = A unique world, Kerbin has flat plains, soaring mountains and wide, blue oceans. Home to the Kerbals, it has just the right conditions to support a vast, seemingly undepletable population of the eager green creatures.
+		
+		MunInSpaceHigh = The Mun, is a large satellite orbiting Kerbin. It is mostly grey in appearance, with craters of various sizes dotting its otherwise smooth surface.
+		
+		MinmusInSpaceHigh = Minmus is the smallest moon orbiting Kerbin. From the surface of Kerbin, it can be seen on clear days as a tiny blue speck in the sky. It is often mistaken as dirt on the telescope lenses or dead pixels but the top minds at the Kerbal Astronomical Society assure us that it is a real moon never the less.
+		
+		DunaInSpaceHigh = Also known as the red dot that you can see if you squint at it really hard, Duna has long been a wonder to Kerbalkind.
+		
+		IkeInSpaceHigh = Ike is a relatively large, grey object occasionally seen orbiting Duna. Scientists have postulated that Ike is seemingly perfectly positioned to sneakily interfere with any object that presumes to come orbiting near its parent.
+		
+		DresInSpaceHigh = Dres is a very small planet. It was the first planet considered to be a dwarf. Its orbit is highly irregular and, together with its size, it took a long time to discover since half the time it was not where scientists expected to find a planet. Due to its nature of frequenting the bad parts of space. This dwarf planet was officially labeled as Not to be trusted by the scientific community.
+		
+		JoolInSpaceHigh = Jool is particularly known for being a rather large, predominantly green planet. Kerbalkind has longed to visit it since it was first spotted in the sky. Philosophers reason that the swirling green planet must be a really nice place to visit, on account of its wholesome coloration. If you look at Jool through a telescope, it is fuzzy.
+		
+		VallInSpaceHigh = Vall was one of the last Moons of Jool to be discovered. Frustrated scientists kept trying to wipe it off the lenses of their telescopes. Eventually after a rash of returned telescopes, Advanced Optics Co. finally decided to just tell them it was an actual object in the sky.
+		
+		TyloInSpaceHigh = Tylo was the first moon of Jool to be discovered by the Kerbal Astronomical Society. After many failed attempts to take a flawless picture of Jool to hang on the office walls, it was finally discovered that the wandering white smear was indeed a moon. Scientists speculate that the view from the surface with Laythe, Vall, and Jool overhead must be quite something.
+		
+		BopInSpaceHigh = Bop is a small moon in the vicinity of Jool. In Kerbal mythology, Bop is believed to be the home of the Kraken, a mischievous creature said to play with the ships of hapless explorers by spinning them out of control until torn asunder, then casting them into oblivion.
+		
+		PolInSpaceHigh = This moon was especially hard to spot, as it looks just like a pollen grain, particularly when observed through telescopes based near dusty fields. Pol was finally discovered when someone decided to write down the location of the pollen, after given up on yet another failed attempt to be rid of the smudge.
+		
+		EelooInSpaceHigh = There’s been a considerable amount of controversy status of Eeloo as being a proper planet or just a lump of ice going around the sun. The debate is still ongoing, as most academic summits held to address the issue have devolved into, on good days, petty name calling, and on worse ones, all-out brawls.
+		
+		MohoInSpaceHigh = Moho figures in Kerbal mythology as a fiery place with oceans of flowing lava. In reality, however, it's much less interesting. Scientists speculate about possible ways to make it awesome like in the stories. Some of those ideas have led to new breakthroughs in aerospace technology.
+		
+		EveInSpaceHigh = Eve is certainly the purplest object in the solar system. Its one of the larger, most visible objects, mainly because of its very, very purple tint. It is considered by some to be an almost sister planet to Kerbin. Well, despite the purple, and the toxic atmosphere, and the extreme pressures and temperatures… Actually, it’s not very similar at all is it? Who are these people?
+		
+		GillyInSpaceHigh = Gilly is a lumpy rock wandering around the orbit of Eve. Its by far the smallest natural satellite that the Kerbal Astronomical Society has discovered. Due to the large amount of squinting and eye strain associated with its discovery, wearing glasses has now become synonymous with becoming an accomplished Astronomer.
 	}
 }
 EXPERIMENT_DEFINITION


### PR DESCRIPTION
I'm not a big fan of the default science message so I edited ScienceDefs so that each planet has a unique observation report. It's a very minor change so I don't think it'll break anything. I have tested it in my game and it works great as seen as in these screenshots:

https://imgur.com/a/cbz0J#0

If you approve this, I can also do the same for asteroids and planet packs. Also, you may notice that the reports I used are the same as the planet descriptions from the wiki. I can change them if you wish but I thought that they were very appropriate.

For your consideration.
