### PR TITLE
Adds asteroid observation and OPM planet pack science reports

### DIFF
--- a/CactEye 2 BETA 5/GameData/CactEye/Resources/OPMScienceDefs.cfg
+++ b/CactEye 2 BETA 5/GameData/CactEye/Resources/OPMScienceDefs.cfg
@@ -1,0 +1,26 @@
+//This file adds support for the Outer Planets Mod by CaptRobau and Eudae55.
+//Note that Eeloo's default science report is replaced with a different one because this mod turns into one of Sarnus' moons.
+
+@EXPERIMENT_DEFINITION[*]:HAS[#id[CactEyePlanetary]]:NEEDS[OPM]
+{
+	%RESULTS
+	{
+		SarnusInSpaceHigh = Early astronomers believed Sarnus were in fact multiple planets, closely orbiting together. When they cleaned their telescopes, they realized that those extra planets were in fact thin rings orbiting Sarnus. Regular cleaning of telescope lenses became mandatory after that.
+		
+		HaleInSpaceHigh = This small moonlet orbiting in the rings of Sarnus is named after Hale, a female shepherd from Kerbal mythology who saved the galaxy from certain destruction. Its location in Sarnus' rings results in some of the finest views in the Kerbol system.
+		
+		OvokInSpaceHigh = Ovok's characteristic smooth shape is caused by the tidal force exerted by Sarnus and Ovok's gravity. This has led scientists to believe that the moon must consist of an icy fluff, that easily contracts and expands, resulting in a landscape that is free of deep impact craters. The moon was named for Ovok, a mythological beast known for its soft fur and razor-like claws.
+		
+		%EelooInSpaceHigh = Until recently astronomers thought Eeloo was a dwarf planet beyond Neidon's orbit. It actually turned out to be a moon of Sarnus and they all this time it had for some reason been confused with the distant dwarf planet Plock. Scientists think the moon might harbor a liquid ocean beneath its frozen crust.
+		
+		SlateInSpaceHigh = Evidence suggests that Slate was very much like Kerbin until only a few hundred thousand years ago. An unknown cataclysm seems to have stripped the moon of its atmosphere and leaving nothing but a dead husk behind. Its vibrant orange and brown color palette has inspired painters ever since its discovery, including the world-renowned Vincent van Kerman.
+		
+		TektoInSpaceHigh = This moon has a very dense atmosphere for a body its size. Combined with the low gravity, this means that a Kerbal with wings attached to his arms could lift off from the surface of the moon under his own power. Those wings would have to be made of some sturdy materials though, as Tekto's atmosphere appears to very violent.
+		
+		UrlumInSpaceHigh = It took a while for Kerbal astronomers to realize Urlum was not a far away star, but in fact another planet. Since then scientists have been weary of making claims about Urlum, for fear of being wrong yet again. The ice giant is unusual in that it rotates around its axis in a clockwise fashion, unlike the anti-clockwise rotation of the other planets.
+		
+		NeidonInSpaceHigh = Due to its distance from Kerbin, it wasn't until fairly recently that Kerbalkind discovered the Kerbol system's most distant planet. At first scientists thought Neidon might a purple, rocky planet like Eve, but they quickly realized they were in fact looking at an ice giant similar to Urlum.
+		
+		PlockInSpaceHigh = There’s been a considerable amount of controversy status of Plock as being a proper planet or just a lump of ice going around the Sun. The debate is still ongoing, as most academic summits held to address the issue have devolved into, on good days, petty name calling, and on worse ones, all-out brawls.
+	}
+}

--- a/CactEye 2 BETA 5/GameData/CactEye/Resources/ScienceDefs.cfg
+++ b/CactEye 2 BETA 5/GameData/CactEye/Resources/ScienceDefs.cfg
@@ -70,7 +70,7 @@ EXPERIMENT_DEFINITION
 	biomeMask = 0
 	RESULTS
 	{
-		default = You make an observation of the asteroid.
+		default = Class A asteroids are really rather small. This particular subject seems to measure about 3 metres across and maaaybe 10 tons soaking wet. You can almost put it in your pocket! Well, if you had a pocket that was 3 metres across...they have those, right?   
 	}
 }
 EXPERIMENT_DEFINITION
@@ -100,7 +100,7 @@ EXPERIMENT_DEFINITION
 	biomeMask = 0
 	RESULTS
 	{
-		default = You make an observation of the asteroid.
+		default = These B-class asteroids are a step up from the A-class in both size and mass. This one appears to adhere to that guideline, if only slightly. It's gonna take a bit of finagling if you want to bring this one home.
 	}
 }
 EXPERIMENT_DEFINITION
@@ -130,7 +130,7 @@ EXPERIMENT_DEFINITION
 	biomeMask = 0
 	RESULTS
 	{
-		default = You make an observation of the asteroid.
+		default = Ah, if it isn't a Class C! Pretty standard space rock, not too big, not too small. Definitely something to keep an eye out for though. An asteroid this size could knock out KSC if it was in the wrong place at the wrong time.
 	}
 }
 EXPERIMENT_DEFINITION
@@ -160,7 +160,7 @@ EXPERIMENT_DEFINITION
 	biomeMask = 0
 	RESULTS
 	{
-		default = You make an observation of the asteroid.
+		default = On the larger end of the scale, class-D asteroids can mass up to several hundred tons of rock and ice. This one would make an excellent addition to any space station.
 	}
 }
 EXPERIMENT_DEFINITION
@@ -190,7 +190,7 @@ EXPERIMENT_DEFINITION
 	biomeMask = 0
 	RESULTS
 	{
-		default = You make an observation of the asteroid.
+		default = Look at the size of that monstrosity! You're quite certain that Class E stands for Enormous. Because it is. You can't wait to show this to the other guys...it's gonna rock their world, hahaha. Hopefully not literally. That would be bad.
 	}
 }
 EXPERIMENT_DEFINITION


### PR DESCRIPTION
Asteroid observation reports now have new reports. Unable to test this because trying to use asteroid processors seems to trigger an error. This occurs even with a clean KSP install and a clean copy of CactEye. Logs attached below:

KSP.log
https://drive.google.com/file/d/0B4kye-yH5Y80QlBGendSMTcxcE0/view?usp=sharing

Player.log
https://drive.google.com/file/d/0B4kye-yH5Y80QWpheEc1SFZkVXM/view?usp=sharing

On the bright side, CactEye works beautifully with the Outer Planets Mod. I added science reports for OPM in a separate config that should only be read when OPM is present in an install. This is necessary because it changes Eeloo's position and thus description.

For your consideration.